### PR TITLE
Fixing IndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/flaptor/indextank/apiclient/IndexTankClient.java
+++ b/src/main/java/com/flaptor/indextank/apiclient/IndexTankClient.java
@@ -857,10 +857,11 @@ public class IndexTankClient implements ApiClient {
                     Boolean added = (Boolean) result.get("added");
 
                     addeds.add(i, added);
+                    errors.add(i, null);    // populate every index position to avoid IndexOutOfBoundsException below
 
                     if (!added) {
                         hasErrors = true;
-                        errors.add(i, (String) result.get("error"));
+                        errors.set(i, (String) result.get("error"));
                     }
                 }
 


### PR DESCRIPTION
I encountered an IndexOutOfBoundsException when adding docs in batches of 100.  Looks like it was caused because the java client was calling errors.add(i, ...) when it hadn't been called for i-1 previously.
